### PR TITLE
Remove implicit enabling of Mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ us to demonstrate the reversing behaviour within the `randdev` function:
 
 ```julia
 using Mocking
-Mocking.enable()  # Not necessary on Julia 0.5- and above
+Mocking.enable()  # Need to enable before we import any code using the `@mock` macro
+
+using Base.Test
+import ...: randdev
 
 ...
 

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -10,13 +10,6 @@ export @patch, @mock, Patch, apply
 global ENABLED = false
 global PATCH_ENV = nothing
 
-function __init__()
-    # Attempt to detect when Mocking has been imported while running within Pkg.test()
-    if isdefined(Base, :PROGRAM_FILE) && basename(Base.PROGRAM_FILE) == "runtests.jl"
-        enable()
-    end
-end
-
 function enable()
     ENABLED::Bool && return  # Abend early if enabled has already been set
     global ENABLED = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,5 @@
 using Mocking
-
-# Note: Explicitly setting Mocking.ENABLE should only be needed on Julia 0.4
-if VERSION < v"0.5-"
-    Mocking.enable()
-end
+Mocking.enable()
 
 using Base.Test
 import Mocking: apply


### PR DESCRIPTION
Removes the functionality which automatically called `Mocking.enable()` in Julia 0.5+. This functionality was being triggered unintentionally too often which could lead to confusion.

Fixes #7 