### PR TITLE
WIP: Support dot-syntax vectorization calls

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -156,3 +156,11 @@ function call_parameters(expr::Expr)
     end
     return positional
 end
+
+function is_call(expr::Expr)
+    return if expr.head == :call  # f(x)
+        true
+    elseif expr.head == :.
+        isa(expr.args[2], Expr) && expr.args[2].head == :tuple  # f.(x)
+    end
+end


### PR DESCRIPTION
The [broadcast short form](http://julia.readthedocs.io/en/latest/manual/functions/#dot-syntax-for-vectorizing-functions) is essentially a modification to a function call. Mocking should work with this syntax and potentially should also be extended to work with `map` and `broadcast` style functions.

- [x] Identify broadcast short form expressions as a call
- [ ] Update mock macro to work with broadcast short form


