### PR TITLE
Fixes for automatic recompilation of dependent functions

### DIFF
--- a/test/closure.jl
+++ b/test/closure.jl
@@ -1,6 +1,6 @@
 let magic
     magic(x) = false
-    sentinel = gensym()
+    sentinel = gensym("sentinel")
     @test magic(sentinel) == false
 
     # Getting closers to work means having a function created in the current scope

--- a/test/concept.jl
+++ b/test/concept.jl
@@ -39,7 +39,7 @@ Mocking.set_active_env(pe)
 @test (@mock multiply(0x2)) == 0x4
 @test (@mock multiply(2//1)) == 4//1
 
-# Use convienient syntax
+# Use convenient syntax
 apply(patches) do
     @test (@mock multiply(2)) == 8
     @test (@mock multiply(0x2)) == 0x6


### PR DESCRIPTION
The Julia PR https://github.com/JuliaLang/julia/pull/17057 (the fix for issue https://github.com/JuliaLang/julia/issues/265) introduced some changes which made it invalid to call a function which was compiled after the function containing the call was compiled. This particular problem would occur when using the `apply` do-block patching.