### PR TITLE
Programmatically disable compile-modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ notifications:
     on_failure: change
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mocking")'
-  - OPTIONS=$(julia -e 'using Mocking; print(DISABLE_PRECOMPILE_STR)')
-  - julia $OPTIONS -e 'Pkg.test("Mocking"; coverage=true)';
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mocking"); Pkg.test("Mocking"; coverage=true)';
 after_success:
   - julia -e 'cd(Pkg.dir("Mocking")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ correctly with Mocking unless you start Julia with `--compiled-modules=no` (>=0.
 $ julia --compilecache=no -e Pkg.test("...")
 ```
 
-Examples of how to add this flag within Appveyor and Travis can be found in Mocking's own
-[appveyor.yml](appveyor.yml) and [.travis.yml](.travis.yml) files.
+Alternatively you can use `Mocking.enable(force=true)` to automatically disable using
+package precompilation for you (experimental). Make sure to call `enable` before the you
+importing the module you are testing.
 
 
 License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,4 +32,4 @@ build_script:
       Pkg.clone(pwd(), \"Mocking\"); Pkg.build(\"Mocking\")"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "using Mocking; run(`$(Base.julia_cmd()) $DISABLE_PRECOMPILE_CMD -e Pkg.test(\\\"Mocking\\\")`)"
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Mocking\")"

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -4,6 +4,7 @@ module Mocking
 
 include("expr.jl")
 include("bindings.jl")
+include("options.jl")
 
 export @patch, @mock, Patch, apply, DISABLE_PRECOMPILE_STR, DISABLE_PRECOMPILE_CMD
 
@@ -11,41 +12,22 @@ export @patch, @mock, Patch, apply, DISABLE_PRECOMPILE_STR, DISABLE_PRECOMPILE_C
 global ENABLED = false
 global PATCH_ENV = nothing
 
-const PRECOMPILE_FLAG = if VERSION >= v"0.7.0-DEV.1698"
-    Symbol("compiled-modules")
-else
-    :compilecache
-end
-
-const PRECOMPILE_FIELD = if VERSION >= v"0.7.0-DEV.1698"
-    :use_compiled_modules
-else
-    :use_compilecache
-end
-
-const DISABLE_PRECOMPILE_STR = "--$PRECOMPILE_FLAG=no"
-const DISABLE_PRECOMPILE_CMD = `$DISABLE_PRECOMPILE_STR`
-
-function is_precompile_enabled()
-    opts = Base.JLOptions()
-    field = PRECOMPILE_FIELD
-
-    # When the pre-compile field is empty it means pre-compilation is unsupported. If the
-    # pre-compile field is missing that means pre-compilation to be assumed to be enabled.
-    return field != Symbol() && (!isdefined(opts, field) || Bool(getfield(opts, field)))
-end
-
-function enable()
+function enable(; force::Bool=false)
     ENABLED::Bool && return  # Abend early if enabled has already been set
     global ENABLED = true
     global PATCH_ENV = PatchEnv()
 
-    # TODO: Support programatically disabling the use of the pre-compilation flag.
     if is_precompile_enabled()
-        warn(
-            "Mocking.jl will probably not work when $PRECOMPILE_FLAG is enabled. " *
-            "Please start Julia with `$DISABLE_PRECOMPILE_STR`",
-        )
+        if force
+            # Disable using pre-compiled packages when Mocking is enabled
+            use_precompile(false)
+        else
+            warn(
+                "Mocking.jl will probably not work when $PRECOMPILE_FLAG is enabled. " *
+                "Please start Julia with `$DISABLE_PRECOMPILE_STR` " *
+                "or alternatively call `Mocking.enable(force=true).`"
+            )
+        end
     end
 end
 

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -5,8 +5,9 @@ module Mocking
 include("expr.jl")
 include("bindings.jl")
 include("options.jl")
+include("deprecated.jl")
 
-export @patch, @mock, Patch, apply, DISABLE_PRECOMPILE_STR, DISABLE_PRECOMPILE_CMD
+export @patch, @mock, Patch, apply, DISABLE_COMPILE_MODULES_STR, DISABLE_COMPILE_MODULES_CMD
 
 # When ENABLED is false the @mock macro is a noop.
 global ENABLED = false
@@ -23,9 +24,9 @@ function enable(; force::Bool=false)
             use_precompile(false)
         else
             warn(
-                "Mocking.jl will probably not work when $PRECOMPILE_FLAG is enabled. " *
-                "Please start Julia with `$DISABLE_PRECOMPILE_STR` " *
-                "or alternatively call `Mocking.enable(force=true).`"
+                "Mocking.jl will probably not work when $COMPILE_MODULES_FLAG is enabled. ",
+                "Please start Julia with `$DISABLE_COMPILE_MODULES_STR` ",
+                "or alternatively call `Mocking.enable(force=true).`",
             )
         end
     end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,11 @@
+import Base: @deprecate_binding
+
+# BEGIN Mocking 0.4 deprecations
+
+@deprecate_binding PRECOMPILE_FLAG COMPILE_MODULES_FLAG false
+@deprecate_binding PRECOMPILE_FIELD COMPILE_MODULES_FIELD false
+
+@deprecate_binding DISABLE_PRECOMPILE_STR DISABLE_COMPILE_MODULES_STR
+@deprecate_binding DISABLE_PRECOMPILE_CMD DISABLE_COMPILE_MODULES_CMD
+
+# END Mocking 0.4 deprecations

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,0 +1,58 @@
+const PRECOMPILE_FLAG = if VERSION >= v"0.7.0-DEV.1698"
+    Symbol("compiled-modules")
+else
+    :compilecache
+end
+
+const PRECOMPILE_FIELD = if VERSION >= v"0.7.0-DEV.1698"
+    :use_compiled_modules
+else
+    :use_compilecache
+end
+
+const DISABLE_PRECOMPILE_STR = "--$PRECOMPILE_FLAG=no"
+const DISABLE_PRECOMPILE_CMD = `$DISABLE_PRECOMPILE_STR`
+
+# Generate a mutable version of JLOptions
+let
+    T = Base.JLOptions
+    fields = [:($(fieldname(T,i))::$(fieldtype(T,i))) for i in 1:nfields(T)]
+
+    @eval begin
+        type JLOptionsMutable
+            $(fields...)
+        end
+    end
+end
+
+function is_precompile_enabled()
+    opts = Base.JLOptions()
+    field = PRECOMPILE_FIELD
+
+    # When the pre-compile field is empty it means pre-compilation is unsupported. If the
+    # pre-compile field is missing that means pre-compilation to be assumed to be enabled.
+    return field != Symbol() && (!isdefined(opts, field) || Bool(getfield(opts, field)))
+end
+
+"""
+    use_precompile(state::Bool) -> Void
+
+Override the Julia command line flag `--$PRECOMPILE_FLAG` with a runtime setting. Code run
+before this the value is modified will use the original setting. Not meant for general
+purpose usage.
+"""
+function use_precompile(state::Bool)
+    value = Base.convert(Int8, state)
+
+    # Load the C global into a mutable Julia type
+    jl_options = cglobal(:jl_options, JLOptionsMutable)
+    opts = unsafe_load(jl_options)
+
+    # Avoid modifying the global when the value hasn't changed
+    if getfield(opts, PRECOMPILE_FIELD) != value
+        setfield!(opts, PRECOMPILE_FIELD, value)
+        unsafe_store!(jl_options, opts)
+    end
+
+    nothing
+end

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,17 +1,19 @@
-const PRECOMPILE_FLAG = if VERSION >= v"0.7.0-DEV.1698"
+# Name of the `julia` command-line option
+const COMPILE_MODULES_FLAG = if VERSION >= v"0.7.0-DEV.1698"
     Symbol("compiled-modules")
 else
     :compilecache
 end
 
-const PRECOMPILE_FIELD = if VERSION >= v"0.7.0-DEV.1698"
+# Name of the field in the JLOptions structure which corresponds to the command-line option
+const COMPILE_MODULES_FIELD = if VERSION >= v"0.7.0-DEV.1698"
     :use_compiled_modules
 else
     :use_compilecache
 end
 
-const DISABLE_PRECOMPILE_STR = "--$PRECOMPILE_FLAG=no"
-const DISABLE_PRECOMPILE_CMD = `$DISABLE_PRECOMPILE_STR`
+const DISABLE_COMPILE_MODULES_STR = "--$COMPILE_MODULES_FLAG=no"
+const DISABLE_COMPILE_MODULES_CMD = `$DISABLE_COMPILE_MODULES_STR`
 
 # Generate a mutable version of JLOptions
 let
@@ -27,7 +29,7 @@ end
 
 function is_precompile_enabled()
     opts = Base.JLOptions()
-    field = PRECOMPILE_FIELD
+    field = COMPILE_MODULES_FIELD
 
     # When the pre-compile field is empty it means pre-compilation is unsupported. If the
     # pre-compile field is missing that means pre-compilation to be assumed to be enabled.
@@ -37,9 +39,9 @@ end
 """
     use_precompile(state::Bool) -> Void
 
-Override the Julia command line flag `--$PRECOMPILE_FLAG` with a runtime setting. Code run
-before this the value is modified will use the original setting. Not meant for general
-purpose usage.
+Override the Julia command line flag `--$COMPILE_MODULES_FLAG` with a runtime setting.
+Code run before this the value is modified will use the original setting. Not meant for
+general purpose usage.
 """
 function use_precompile(state::Bool)
     value = Base.convert(Int8, state)
@@ -49,8 +51,9 @@ function use_precompile(state::Bool)
     opts = unsafe_load(jl_options)
 
     # Avoid modifying the global when the value hasn't changed
-    if getfield(opts, PRECOMPILE_FIELD) != value
-        setfield!(opts, PRECOMPILE_FIELD, value)
+    if getfield(opts, COMPILE_MODULES_FIELD) != value
+        warn("Using experimental code which modifies jl_options global struct")
+        setfield!(opts, COMPILE_MODULES_FIELD, value)
         unsafe_store!(jl_options, opts)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Mocking
-Mocking.enable()
+Mocking.enable(force=true)
 
 VERSION < v"0.7-" && import Compat: Test
 using Test


### PR DESCRIPTION
When `--compile-modules=yes` (formerly `--compilecache=yes`) is enabled during a `Pkg.test` it is quite likely that the `@mock` will not work as they have been pre-compiled as no-ops. Currently  if `Pkg.test` is run with compile modules enabled Mocking will report a warning and the tests that require Mocking can be skipped.

Unfortunately, for packages that rely heavily on mocked tests skipping most of the test suite isn't a great solution and some tools, like the JuliaCIBot, provide the user has no control of the options Julia is run with.

This PR provides a mechanism to set `--compile-modules=no` from within Julia itself by modifying the JLOptions C global.
