### PR TITLE
Update pair generation expression

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -84,7 +84,7 @@ macro patch(expr::Expr)
 
     translations = []
     for b in bindings
-        push!(translations, Expr(:(=>), QuoteNode(b), b))
+        push!(translations, Expr(:call, :(=>), QuoteNode(b), b))
     end
 
     return esc(:(Mocking.Patch( $signature, $func, Dict($(translations...)) )))


### PR DESCRIPTION
On Julia 0.6 the old pair expression was producing errors:

```
LoadError: syntax: invalid syntax (=> (inert Integer) (outerref Integer))
```

The new expression appears compatible with Julia 0.4 onwards.