### PR TITLE
Added support for kwargs in `@mock` calls.

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -163,3 +163,27 @@ function rewrite_do(expr::Expr)
     call, body = expr.args
     Expr(:call, call.args[1], body, call.args[2:end]...)
 end
+
+iskwarg(x::Any) = isa(x, Expr) && (x.head === :parameters || x.head === :kw)
+
+"""
+    extract_kwargs(expr::Expr) -> Vector{Expr}
+
+Extract the :parameters and :kw value into an array of :kw expressions
+we don't evaluate any expressions for values yet though.
+"""
+function extract_kwargs(expr::Expr)
+    kwargs = Expr[]
+    for x in expr.args[2:end]
+        if Mocking.iskwarg(x)
+            if x.head === :parameters
+                for kw in x.args
+                    push!(kwargs, kw)
+                end
+            else
+                push!(kwargs, x)
+            end
+        end
+    end
+    return kwargs
+end

--- a/test/optional.jl
+++ b/test/optional.jl
@@ -19,6 +19,9 @@ end
     patch = @patch hourvalue(; hour::Hour=Hour(21)) = 2 * Dates.value(hour)
     apply(patch) do
         @test (@mock hourvalue()) == 42
-        # @test (@mock hourvalue(hour=Hour(4))) == 8  # TODO
+
+        # Test @mock calls with keyword arguments
+        @test (@mock hourvalue(hour=Hour(4))) == 8      #:kw
+        @test (@mock hourvalue(; hour=Hour(4))) == 8    #:parameters
     end
 end


### PR DESCRIPTION
Handles `@mock` calls with keyword arguments (both `:parameters` and regular `:kw`). Currently, left the `QuoteNode` on kwarg values out as it won't be necessary with #20.

Fixes: #19