### PR TITLE
Overhaul binding extraction

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -34,8 +34,16 @@ immutable Patch
     function Patch(signature::Expr, body::Function, translation::Dict)
         trans = adjust_bindings(translation)
         sig = name_parameters(absolute_signature(signature, trans))
-        # Square brackets only needed on Julia 0.4
-        modules = Set([b.args[1] for b in values(trans) if isa(b, Expr)])
+
+        # On VERSION >= v"0.5"
+        # modules = Set(b.args[1] for b in values(trans) if isa(b, Expr))
+        modules = Set()
+        for b in values(trans)
+            if isa(b, Expr)
+                push!(modules, b.args[1])
+            end
+        end
+
         new(sig, body, modules)
     end
 end

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -33,7 +33,7 @@ immutable Patch
 
     function Patch(signature::Expr, body::Function, translation::Dict)
         trans = adjust_bindings(translation)
-        sig = absolute_signature(signature, trans)
+        sig = name_parameters(absolute_signature(signature, trans))
         modules = Set([v.args[1] for v in values(trans)])  # Square brackets only needed on Julia 0.4
         new(sig, body, modules)
     end
@@ -157,7 +157,7 @@ end
 function ismocked(pe::PatchEnv, func_name::Symbol, args::Tuple)
     if isdefined(pe.mod, func_name)
         func = Core.eval(pe.mod, func_name)
-        types = map(typeof, tuple(args...))
+        types = map(arg -> isa(arg, Type) ? Type{arg} : typeof(arg), args)
         exists = method_exists(func, types)
 
         if pe.debug

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -34,7 +34,8 @@ immutable Patch
     function Patch(signature::Expr, body::Function, translation::Dict)
         trans = adjust_bindings(translation)
         sig = name_parameters(absolute_signature(signature, trans))
-        modules = Set([v.args[1] for v in values(trans)])  # Square brackets only needed on Julia 0.4
+        # Square brackets only needed on Julia 0.4
+        modules = Set([b.args[1] for b in values(trans) if isa(b, Expr)])
         new(sig, body, modules)
     end
 end

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -161,7 +161,7 @@ function ismocked(pe::PatchEnv, func_name::Symbol, args::Tuple)
         exists = method_exists(func, types)
 
         if pe.debug
-            info("calling $func_name($(types...))")
+            info("calling $func_name$(types)")
             if exists
                 m = first(methods(func, types))
                 info("executing mocked function: $m")

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -32,6 +32,13 @@ function ingest_parametric!(b::Bindings, expr::Expr)
         push!(b.internal, defined)
         !(reference in b.internal) && push!(b.external, reference)
 
+    elseif expr.head == :comparison && length(expr.args) == 3 &&
+        expr.args[2] in (:(<:), :(>:)) && VERSION < v"0.5-"
+
+        defined, reference = expr.args[1], expr.args[3]
+        push!(b.internal, defined)
+        !(reference in b.internal) && push!(b.external, reference)
+
     # Chained operator comparison
     elseif expr.head == :comparison && length(expr.args) == 5 &&
         expr.args[2] == expr.args[4] && expr.args[2] in (:(<:), :(>:))

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -190,7 +190,9 @@ function ingest_signature!(b::Bindings, expr::Expr)
 
     # f(...) where T
     elseif expr.head == :where
-        push!(b.internal, expr.args[2])
+        for parametric in expr.args[2:end]
+            ingest_parametric!(b, parametric)
+        end
         ingest_signature!(b, expr.args[1])
 
     else

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -1,0 +1,187 @@
+# Looks at a function signature and separates the bindings (variable names, function calls,
+# parametric variables) into those created by the function signature and those that are
+# external. The external bindings will be turned into absolute bindings.
+
+immutable Bindings
+    internal::Set
+    external::Set
+end
+
+Bindings() = Bindings(Set(), Set())
+
+function Bindings(internal::AbstractArray, external::AbstractArray)
+    Bindings(Set(internal), Set(external))
+end
+
+"""
+    Bindings(expr)
+
+Takes a function signature expression and extracts all of the bindings into either internal
+(defined by the signature) or external (defined outside of the signature).
+
+```julia
+julia> Bindings(:(f{T<:Integer}(a::T, b::Base.Real=a, c=z)))
+Mocking.Bindings(Set(Any[:c,:T,:a,:b,:f]),Set(Any[:z,:(Base.Real),:Integer]))
+```
+"""
+Bindings(expr::Expr) = ingest_signature!(Bindings(), expr)
+
+function ingest_parametric!(b::Bindings, expr::Expr)
+    if expr.head in (:(<:), :(>:))
+        defined, reference = expr.args
+        push!(b.internal, defined)
+        !(reference in b.internal) && push!(b.external, reference)
+
+    # Chained operator comparison
+    elseif expr.head == :comparison && length(expr.args) == 5 &&
+        expr.args[2] == expr.args[4] && expr.args[2] in (:(<:), :(>:))
+
+        reference_before = expr.args[1]
+        defined = expr.args[3]
+        reference_after = expr.args[5]
+
+        # Note chaining more than two operators here is unsupported by Julia
+        !(reference_before in b.internal) && push!(b.external, reference_before)
+        push!(b.internal, defined)
+        !(reference_after in b.internal) && push!(b.external, reference_after)
+    else
+        error("expression is not valid parametric expression: $expr")
+    end
+    return b
+end
+
+function ingest_parametric!(b::Bindings, sym::Symbol)
+    push!(b.internal, sym)
+    return b
+end
+
+function ingest_assertion!(b::Bindings, expr::Expr)
+    # Tuple{Int}
+    if expr.head == :curly
+        for ex in expr.args
+            ingest_assertion!(b, ex)
+        end
+
+    # ...{<:Integer}
+    elseif expr.head == :call && expr.args[1] in (:(<:), :(>:))
+        reference = expr.args[2]
+        !(reference in b.internal) && push!(b.external, reference)
+
+    # Core.Int and Base.Random.rand
+    elseif expr.head == :.
+        reference = expr
+        !(reference in b.internal) && push!(b.external, reference)
+
+    else
+        error("expression is not type assertion: $expr")
+    end
+    return b
+end
+
+function ingest_assertion!(b::Bindings, sym::Symbol)
+    !(sym in b.internal) && push!(b.external, sym)
+    return b
+end
+
+ingest_assertion!(b::Bindings, ::Any) = b
+
+function ingest_default!(b::Bindings, expr::Expr)
+    if expr.head == :call
+        func, args = expr.args[1], expr.args[2:end]
+        !(func in b.internal) && push!(b.external, func)
+        for arg in args
+            ingest_default!(b, arg)
+        end
+
+    elseif expr.head == :...
+        for arg in expr.args
+            ingest_default!(b, arg)
+        end
+
+    else
+        error("expression is not valid as a parameter default: $expr")
+    end
+    return b
+end
+
+function ingest_default!(b::Bindings, sym::Symbol)
+    !(sym in b.internal) && push!(b.external, sym)
+    return b
+end
+
+ingest_default!(b::Bindings, ::Any) = b
+
+function ingest_parameter!(b::Bindings, expr::Expr)
+    # Positional parameter
+    if expr.head == :(::) && length(expr.args) == 2
+        defined, reference = expr.args
+        push!(b.internal, defined)
+        ingest_assertion!(b, reference)
+
+    # Anonymous positional parameter
+    elseif expr.head == :(::) && length(expr.args) == 1
+        reference, = expr.args
+        ingest_assertion!(b, reference)
+
+    # Optional parameter
+    elseif expr.head == :kw
+        parameter, value = expr.args
+        ingest_parameter!(b, parameter)
+        ingest_default!(b, value)
+
+    # Keyword parameters
+    elseif expr.head == :parameters
+        for parameter in expr.args
+            ingest_parameter!(b, parameter)
+        end
+
+    # Varargs parameter
+    elseif expr.head == :...
+        for parameter in expr.args
+            ingest_parameter!(b, parameter)
+        end
+
+    else
+        error("expression is not valid as a parameter: $expr")
+    end
+    return b
+end
+
+function ingest_parameter!(b::Bindings, sym::Symbol)
+    push!(b.internal, sym)
+    return b
+end
+
+function ingest_signature!(b::Bindings, expr::Expr)
+    if expr.head == :call
+        func = expr.args[1]
+
+        # f(...)
+        if isa(func, Symbol)
+            push!(b.internal, func)
+
+        # f{T}(...)
+        elseif isa(func, Expr) && func.head == :curly
+            push!(b.internal, func.args[1])
+            for parametric in func.args[2:end]
+                ingest_parametric!(b, parametric)
+            end
+        else
+            error("expression is not a valid function call: $func")
+        end
+
+        # Function parameters and keywords
+        for parameter in expr.args[2:end]
+            ingest_parameter!(b, parameter)
+        end
+
+    # f(...) where T
+    elseif expr.head == :where
+        push!(b.internal, expr.args[2])
+        ingest_signature!(b, expr.args[1])
+
+    else
+        error("expression is not valid as signature: $expr")
+    end
+    return b
+end

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -62,13 +62,18 @@ function ingest_assertion!(b::Bindings, expr::Expr)
             ingest_assertion!(b, ex)
         end
 
+    # ...{<:Integer}
+    elseif expr.head in (:(<:), :(>:))
+        reference = expr.args[1]
+        !(reference in b.internal) && push!(b.external, reference)
+
     # Core.Int and Base.Random.rand
     elseif expr.head == :.
         reference = expr
         !(reference in b.internal) && push!(b.external, reference)
 
-    # ...{<:Integer}
-    elseif expr.head == :call && expr.args[1] in (:(<:), :(>:))
+    # ...{<:Integer} on Julia 0.5 and below
+    elseif expr.head == :call && expr.args[1] in (:(<:), :(>:)) && VERSION < v"0.6"
         reference = expr.args[2]
         !(reference in b.internal) && push!(b.external, reference)
 

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -31,7 +31,9 @@ function binding_expr(t::Type)
     joinbinding(fullname(type_name.module)..., type_name.name)
 end
 function binding_expr(f::Function)
-    isa(f, Core.Builtin) && return Base.function_name(f)
+    if VERSION < v"0.5-" && isgeneric(f) || VERSION >= v"0.5-" && isa(f, Core.Builtin)
+        return Base.function_name(f)
+    end
     m = Base.function_module(f, Tuple)
     joinbinding(fullname(m)..., Base.function_name(f))
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -31,6 +31,7 @@ function binding_expr(t::Type)
     joinbinding(fullname(type_name.module)..., type_name.name)
 end
 function binding_expr(f::Function)
+    isa(f, Core.Builtin) && return Base.function_name(f)
     m = Base.function_module(f, Tuple)
     joinbinding(fullname(m)..., Base.function_name(f))
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -64,6 +64,23 @@ end
 
 absolute_signature(x::Any, translations::Dict) = x
 
+function name_parameters(expr::Expr)
+    if expr.head == :(::) && length(expr.args) == 1
+        return Expr(expr.head, gensym("anon"), expr.args[1])
+        # return Expr(expr.head, :anon, expr.args[1])
+    else
+        num_args = length(expr.args)
+        args = Array{Any}(num_args)
+        for i in 1:num_args
+            args[i] = name_parameters(expr.args[i])
+        end
+        return Expr(expr.head, args...)
+    end
+end
+
+name_parameters(x::Any) = x
+
+
 
 function joinbinding(symbols::Symbol...)
     result = symbols[1]

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -31,8 +31,14 @@ function binding_expr(t::Type)
     joinbinding(fullname(type_name.module)..., type_name.name)
 end
 function binding_expr(f::Function)
-    if VERSION < v"0.5-" && isgeneric(f) || VERSION >= v"0.5-" && isa(f, Core.Builtin)
+    if VERSION >= v"0.5-" && isa(f, Core.Builtin)
         return Base.function_name(f)
+    elseif VERSION < v"0.5-" && !isgeneric(f)
+        if isdefined(f, :env) && isa(f.env, Symbol)
+            return f.env
+        else
+            return Base.function_name(f)
+        end
     end
     m = Base.function_module(f, Tuple)
     joinbinding(fullname(m)..., Base.function_name(f))

--- a/test/anonymous-param.jl
+++ b/test/anonymous-param.jl
@@ -1,8 +1,8 @@
 # Issue #15
 let f, patch
-    f{T<:Unsigned}(::Type{T}, n::Int64) = rand(T, n)
+    f{T<:Unsigned}(::Type{T}, n::Int) = rand(T, n)
 
-    patch = @patch f(::Type{UInt8}, n::Int64) = collect(UnitRange{UInt8}(1:n))
+    patch = @patch f(::Type{UInt8}, n::Int) = collect(UnitRange{UInt8}(1:n))
 
     apply(patch) do
         @test (@mock f(UInt8, 2)) == [0x01, 0x02]

--- a/test/anonymous-param.jl
+++ b/test/anonymous-param.jl
@@ -1,0 +1,10 @@
+# Issue #15
+let f, patch
+    f{T<:Unsigned}(::Type{T}, n::Int64) = rand(T, n)
+
+    patch = @patch f(::Type{UInt8}, n::Int64) = collect(UnitRange{UInt8}(1:n))
+
+    apply(patch) do
+        @test (@mock f(UInt8, 2)) == [0x01, 0x02]
+    end
+end

--- a/test/bindings/bindings.jl
+++ b/test/bindings/bindings.jl
@@ -1,0 +1,22 @@
+function genmod()
+    Core.eval(:(module $(gensym()) end))
+end
+
+macro valid_method(expr)
+    result = quote
+        try
+            !isempty(methods(eval(genmod(), $(esc(expr)))))
+        catch
+            false
+        end
+    end
+    Base.remove_linenums!(result)
+    return result
+end
+
+include("ingest_parametric.jl")
+include("ingest_assertion.jl")
+include("ingest_default.jl")
+include("ingest_parameter.jl")
+include("ingest_signature.jl")
+VERSION >= v"0.6" && include("ingest_signature_0.6.jl")

--- a/test/bindings/bindings.jl
+++ b/test/bindings/bindings.jl
@@ -2,16 +2,20 @@ function genmod()
     Core.eval(:(module $(gensym()) end))
 end
 
+function valid_method(expr::Expr)
+    try
+        !isempty(methods(eval(genmod(), expr)))
+    catch
+        false
+    end
+end
+
 macro valid_method(expr)
     result = quote
-        try
-            !isempty(methods(eval(genmod(), $(esc(expr)))))
-        catch
-            false
-        end
+        valid_method($(QuoteNode(expr)))
     end
     Base.remove_linenums!(result)
-    return result
+    return esc(result)
 end
 
 include("ingest_parametric.jl")

--- a/test/bindings/ingest_assertion.jl
+++ b/test/bindings/ingest_assertion.jl
@@ -55,3 +55,8 @@ b = Bindings()
 ingest_assertion!(b, :(Base.Dates.Hour))
 @test b.internal == Set([])
 @test b.external == Set([:(Base.Dates.Hour)])
+
+b = Bindings()
+ingest_assertion!(b, :(typeof(cos)))
+@test b.internal == Set([])
+@test b.external == Set([:typeof, :cos])

--- a/test/bindings/ingest_assertion.jl
+++ b/test/bindings/ingest_assertion.jl
@@ -1,0 +1,57 @@
+import Mocking: Bindings, ingest_assertion!
+import Base.Dates: Hour
+
+b = Bindings([:T], [])
+ingest_assertion!(b, :T)
+@test b.internal == Set([:T])
+@test b.external == Set()
+
+b = Bindings()
+ingest_assertion!(b, :Int)
+@test b.internal == Set()
+@test b.external == Set([:Int])
+
+b = Bindings()
+ingest_assertion!(b, :(Union{}))
+@test b.internal == Set()
+@test b.external == Set([:Union])
+
+b = Bindings()
+ingest_assertion!(b, :(Tuple{Int,Integer}))
+@test b.internal == Set()
+@test b.external == Set([:Tuple, :Int, :Integer])
+
+b = Bindings([:T], [])
+ingest_assertion!(b, :(AbstractArray{T,1}))
+@test b.internal == Set([:T])
+@test b.external == Set([:AbstractArray])
+
+b = Bindings()
+ingest_assertion!(b, :(AbstractArray{<:Integer}))
+@test b.internal == Set([])
+@test b.external == Set([:AbstractArray, :Integer])
+
+b = Bindings()
+ingest_assertion!(b, :(AbstractArray{>:Integer}))
+@test b.internal == Set([])
+@test b.external == Set([:AbstractArray, :Integer])
+
+b = Bindings()
+ingest_assertion!(b, :(<:Integer))  # Should throw and exception
+@test b.internal == Set([])
+@test b.external == Set([:Integer])
+
+b = Bindings()
+ingest_assertion!(b, :Hour)
+@test b.internal == Set([])
+@test b.external == Set([:Hour])
+
+b = Bindings()
+ingest_assertion!(b, :(Dates.Hour))
+@test b.internal == Set([])
+@test b.external == Set([:(Dates.Hour)])
+
+b = Bindings()
+ingest_assertion!(b, :(Base.Dates.Hour))
+@test b.internal == Set([])
+@test b.external == Set([:(Base.Dates.Hour)])

--- a/test/bindings/ingest_default.jl
+++ b/test/bindings/ingest_default.jl
@@ -1,0 +1,16 @@
+import Mocking: Bindings, ingest_default!
+
+b = Bindings()
+ingest_default!(b, :(1))
+@test b.internal == Set()
+@test b.external == Set()
+
+b = Bindings()
+ingest_default!(b, :Int)
+@test b.internal == Set()
+@test b.external == Set([:Int])
+
+b = Bindings()
+ingest_default!(b, :(f(rand(Bool))))
+@test b.internal == Set()
+@test b.external == Set([:f, :rand, :Bool])

--- a/test/bindings/ingest_parameter.jl
+++ b/test/bindings/ingest_parameter.jl
@@ -36,12 +36,12 @@ ingest_parameter!(b, :(f(a::Int=1)).args[2])
 @test b.external == Set([:Int])
 
 b = Bindings()
-ingest_parameter!(b, :(; a=1).args[1])
+ingest_parameter!(b, :(f(; a=1)).args[2])  # VERSION >= v"0.5-" could be `:(; a=1).args[1]`
 @test b.internal == Set([:a])
 @test b.external == Set([])
 
 b = Bindings()
-ingest_parameter!(b, :(; a::Int=1).args[1])
+ingest_parameter!(b, :(f(; a::Int=1)).args[2])  # VERSION >= v"0.5-" could be `:(; a::Int=1).args[1]`
 @test b.internal == Set([:a])
 @test b.external == Set([:Int])
 

--- a/test/bindings/ingest_parameter.jl
+++ b/test/bindings/ingest_parameter.jl
@@ -1,0 +1,66 @@
+import Mocking: Bindings, ingest_parameter!
+
+b = Bindings()
+ingest_parameter!(b, :a)
+@test b.internal == Set([:a])
+@test b.external == Set([])
+
+b = Bindings()
+ingest_parameter!(b, :(a::Int))
+@test b.internal == Set([:a])
+@test b.external == Set([:Int])
+
+b = Bindings()
+ingest_parameter!(b, :(a::Union{}))
+@test b.internal == Set([:a])
+@test b.external == Set([:Union])
+
+b = Bindings()
+ingest_parameter!(b, :(a::Tuple{Int,Integer}))
+@test b.internal == Set([:a])
+@test b.external == Set([:Tuple, :Int, :Integer])
+
+b = Bindings()
+ingest_parameter!(b, :(f(a=1)).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([])
+
+b = Bindings()
+ingest_parameter!(b, :(f(a=rand())).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([:rand])
+
+b = Bindings()
+ingest_parameter!(b, :(f(a::Int=1)).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([:Int])
+
+b = Bindings()
+ingest_parameter!(b, :(; a=1).args[1])
+@test b.internal == Set([:a])
+@test b.external == Set([])
+
+b = Bindings()
+ingest_parameter!(b, :(; a::Int=1).args[1])
+@test b.internal == Set([:a])
+@test b.external == Set([:Int])
+
+b = Bindings()
+ingest_parameter!(b, :(f(a...)).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([])
+
+b = Bindings()
+ingest_parameter!(b, :(f(a::Int...)).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([:Int])
+
+b = Bindings()
+ingest_parameter!(b, :(f(a::Int=rand(Int)...)).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([:Int, :rand])
+
+b = Bindings()
+ingest_parameter!(b, :(f(; a::Int=rand(Int)...)).args[2])
+@test b.internal == Set([:a])
+@test b.external == Set([:Int, :rand])

--- a/test/bindings/ingest_parametric.jl
+++ b/test/bindings/ingest_parametric.jl
@@ -1,0 +1,81 @@
+import Mocking: Bindings, ingest_parametric!
+
+# Note: The `f{A}` parametric syntax and `where` are equal when looking at individual
+# components.
+
+@test @valid_method f{A}(::Type{A}) = A
+b = Bindings()
+ingest_parametric!(b, :A)
+@test b.internal == Set([:A])
+@test b.external == Set([])
+
+if VERSION >= v"0.6"
+    @test @valid_method f{A,B<:A}(::Type{A}, ::Type{B}) = A, B
+end
+ingest_parametric!(b, :(B<:A))
+@test b.internal == Set([:A, :B])
+@test b.external == Set([])
+
+@test @valid_method f{A<:Integer}(::Type{A}) = A
+b = Bindings()
+ingest_parametric!(b, :(A<:Integer))
+@test b.internal == Set([:A])
+@test b.external == Set([:Integer])
+
+@static if VERSION >= v"0.6"
+    @test @valid_method f{A>:Integer}(::Type{A}) = A
+end
+b = Bindings()
+ingest_parametric!(b, :(A>:Integer))
+@test b.internal == Set([:A])
+@test b.external == Set([:Integer])
+
+@static if VERSION >= v"0.6"
+    @test @valid_method f{Integer<:A<:Real}(::Type{A}) = A
+end
+b = Bindings()
+ingest_parametric!(b, :(Integer<:A<:Real))
+@test b.internal == Set([:A])
+@test b.external == Set([:Integer, :Real])
+
+@test @valid_method f{Int<:Integer}(x::Int) = x
+
+# Invalid parametric
+if VERSION >= v"0.6"
+    @test !@valid_method f{Integer<:A}(::Type{A}) = A
+end
+b = Bindings()
+ingest_parametric!(b, :(Integer<:A))
+@test b.internal == Set([:Integer])
+@test b.external == Set([:A])
+
+@static if VERSION >= v"0.6"
+    @test !@valid_method f{Integer>:A}(::Type{A}) = A
+end
+b = Bindings()
+ingest_parametric!(b, :(Integer>:A))
+@test b.internal == Set([:Integer])
+@test b.external == Set([:A])
+
+@static if VERSION >= v"0.6"
+    @test !@valid_method f{Integer>:A}(::Type{A}) = A
+end
+b = Bindings()
+ingest_parametric!(b, :(Integer>:A))
+@test b.internal == Set([:Integer])
+@test b.external == Set([:A])
+
+@static if VERSION >= v"0.6"
+    @test !@valid_method f{Int<:A>:Int}(::Type{A}) = A
+end
+@test_throws Exception ingest_parametric!(Bindings(), :(Int<:A>:Int))
+
+@static if VERSION >= v"0.6"
+    @test !@valid_method f{Int>:A<:Int}(::Type{A}) = A
+end
+@test_throws Exception ingest_parametric!(Bindings(), :(Int>:A<:Int))
+
+@static if VERSION >= v"0.6"
+    @test !@valid_method f{Int<:A<:Real<:Number}(::Type{A}) = A
+end
+@test_throws Exception ingest_parametric!(Bindings(), :(Int<:A<:Real<:Number))

--- a/test/bindings/ingest_parametric.jl
+++ b/test/bindings/ingest_parametric.jl
@@ -42,7 +42,10 @@ ingest_parametric!(b, :(Integer<:A<:Real))
 
 # Invalid parametric
 if VERSION >= v"0.6"
-    @test !@valid_method f{Integer<:A}(::Type{A}) = A
+    method_expr = quote
+        f{Integer<:A}(::Type{A}) = A
+    end
+    @test !valid_method(method_expr)
 end
 b = Bindings()
 ingest_parametric!(b, :(Integer<:A))
@@ -50,7 +53,10 @@ ingest_parametric!(b, :(Integer<:A))
 @test b.external == Set([:A])
 
 @static if VERSION >= v"0.6"
-    @test !@valid_method f{Integer>:A}(::Type{A}) = A
+    method_expr = quote
+        f{Integer>:A}(::Type{A}) = A
+    end
+    @test !valid_method(method_expr)
 end
 b = Bindings()
 ingest_parametric!(b, :(Integer>:A))

--- a/test/bindings/ingest_signature.jl
+++ b/test/bindings/ingest_signature.jl
@@ -1,0 +1,35 @@
+import Mocking: Bindings, ingest_signature!
+
+@test @valid_method f(x) = x
+b = Bindings()
+ingest_signature!(b, :(f(x) = x).args[1])
+@test b.internal == Set([:f, :x])
+@test b.external == Set()
+
+@test @valid_method f{T}(::Type{T}) = T
+b = Bindings()
+ingest_signature!(b, :(f{T}(::Type{T}) = T).args[1])
+@test b.internal == Set([:f, :T])
+@test b.external == Set([:Type])
+
+if VERSION >= v"0.6"
+    @test @valid_method f{T,S<:T}(x::T, y::S) = (x, y)
+end
+b = Bindings()
+ingest_signature!(b, :(f{T,S<:T}(x::T, y::S) = (x, y)).args[1])
+@test b.internal == Set([:f, :T, :S, :x, :y])
+@test b.external == Set()
+
+@test @valid_method f(x=f) = x  # `f` the argument default refers the the function `f`
+b = Bindings()
+ingest_signature!(b, :(f(x=f)))
+@test b.internal == Set([:f, :x])
+@test b.external == Set()
+
+@test @valid_method f(f) = f  # `f` the function and `f` the parameter variable
+b = Bindings()
+ingest_signature!(b, :(f(f)))
+@test b.internal == Set([:f])  # Wrong? Technically there are two separate `f`s here
+@test b.external == Set()
+
+# f = 1; f(x=f) = f  # Error

--- a/test/bindings/ingest_signature_0.6.jl
+++ b/test/bindings/ingest_signature_0.6.jl
@@ -1,0 +1,13 @@
+# Needs to be in a separate file since not even `@static` can fix the unhandled syntax
+
+@test @valid_method f(x::T, y::S) where S<:T where T = (x, y)
+b = Bindings()
+ingest_signature!(b, :(f(x::T, y::S) where S<:T where T = (x, y)).args[1])
+@test b.internal == Set([:f, :T, :S, :x, :y])
+@test b.external == Set()
+
+@test @valid_method f(x::T, y::S) where {T,S<:T} = (x, y)
+b = Bindings()
+ingest_signature!(b, :(f(x::T, y::S) where {T,S<:T} = (x, y)).args[1])
+@test b.internal == Set([:f, :T, :S, :x, :y])
+@test b.external == Set()

--- a/test/bindings/ingest_signature_0.6.jl
+++ b/test/bindings/ingest_signature_0.6.jl
@@ -1,4 +1,5 @@
 # Needs to be in a separate file since not even `@static` can fix the unhandled syntax
+import Mocking: Bindings, ingest_signature!
 
 @test @valid_method f(x::T, y::S) where S<:T where T = (x, y)
 b = Bindings()

--- a/test/expr.jl
+++ b/test/expr.jl
@@ -1,4 +1,5 @@
 import Base.Dates: Hour
+import Compat: @static
 
 @test Mocking.joinbinding(:Foo) == :(Foo)
 @test Mocking.joinbinding(:Foo, :Bar) == :(Foo.Bar)
@@ -13,6 +14,8 @@ int_expr = Int === Int32 ? :(Core.Int32) : :(Core.Int64)
 @test Mocking.binding_expr(Int64) == :(Core.Int64)  # concrete type
 @test Mocking.binding_expr(Integer) == :(Core.Integer)  # abstract type
 @test Mocking.binding_expr(Hour) == :(Base.Dates.Hour)  # unexported type
+@test Mocking.binding_expr(Dates.Hour) == :(Base.Dates.Hour)  # submodule
+@test Mocking.binding_expr(Base.Dates.Hour) == :(Base.Dates.Hour)  # full type binding
 @test Mocking.binding_expr(rand) == :(Base.Random.rand)  # function
 @test Mocking.binding_expr(AbstractArray{Int64}) == :(Core.AbstractArray)  # Core.AbstractArray{Int64}?
 # @test Mocking.binding_expr(AbstractArray{T}) == :(Core.AbstractArray{T})
@@ -26,21 +29,21 @@ trans = Dict(:Int => Int, :Int64 => Int64, :Integer => Integer)
 
 
 expr = :(f(a, b::Int64, c=3, d::Integer=4; e=5, f::Int=6))
-@test Mocking.extract_bindings(expr.args[2:end]) == Set([:Int64, :Integer, :Int])
+# @test Mocking.extract_bindings(expr.args[2:end]) == Set([:Int64, :Integer, :Int])
 @test Mocking.call_parameters(expr) == [Expr(:parameters, Expr(:kw, :e, :e), Expr(:kw, :f, :f)), :a, :b, :c, :d]
 
 expr = :(f(a..., b::Integer...))
-@test Mocking.extract_bindings(expr.args[2:end]) == Set([:Integer])
+# @test Mocking.extract_bindings(expr.args[2:end]) == Set([:Integer])
 @test Mocking.call_parameters(expr) == Any[Expr(:..., :a), Expr(:..., :b)]
 
 expr = :(f(h::Hour=Hour(rand(1:24))))
-@test Mocking.extract_bindings(expr.args[2:end]) == Set([:Hour, :rand])
+# @test Mocking.extract_bindings(expr.args[2:end]) == Set([:Hour, :rand])
 @test Mocking.call_parameters(expr) == Any[:h]
 
 expr = :(f(a::AbstractArray{Int64}))
-@test Mocking.extract_bindings(expr.args[2:end]) == Set([:(AbstractArray{Int64})])
+# @test Mocking.extract_bindings(expr.args[2:end]) == Set([:(AbstractArray{Int64})])
 @test Mocking.call_parameters(expr) == Any[:a]
 
 expr = :(f{T}(a::AbstractArray{T}))
-@test Mocking.extract_bindings(expr.args[2:end]) == Set([:(AbstractArray{T})])
+# @test Mocking.extract_bindings(expr.args[2:end]) == Set([:(AbstractArray{T})])
 @test Mocking.call_parameters(expr) == Any[:a]

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -17,8 +17,13 @@ p = @patch f(::Type{UInt8}, b::Int64) = nothing
 @test p.modules == Set([:Core])
 
 p = @patch f(t::typeof(cos)) = nothing
-@test p.signature == :(f(t::typeof(Base.MPFR.cos)))
-@test p.modules == Set([:(Base.MPFR)])
+if VERSION < v"0.5-"
+    @test p.signature == :(f(t::typeof(Base.cos)))
+    @test p.modules == Set([:Base])
+else
+    @test p.signature == :(f(t::typeof(Base.MPFR.cos)))
+    @test p.modules == Set([:(Base.MPFR)])
+end
 
 patches = [
     @patch f(h::Base.Dates.Hour=Base.Dates.Hour(rand())) = nothing

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -10,6 +10,12 @@ p = @patch f(a::Integer...) = nothing
 @test p.signature == :(f(a::Core.Integer...))
 @test p.modules == Set([:Core])
 
+# Issue #15
+anon = next_gensym("anon", 2)
+p = @patch f(::Type{UInt8}, b::Int64) = nothing
+@test p.signature == :(f($anon::Core.Type{Core.UInt8}, b::Core.Int64))
+@test p.modules == Set([:Core])
+
 patches = [
     @patch f(h::Base.Dates.Hour=Base.Dates.Hour(rand())) = nothing
     @patch f(h::Dates.Hour=Dates.Hour(rand())) = nothing

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -16,6 +16,10 @@ p = @patch f(::Type{UInt8}, b::Int64) = nothing
 @test p.signature == :(f($anon::Core.Type{Core.UInt8}, b::Core.Int64))
 @test p.modules == Set([:Core])
 
+p = @patch f(t::typeof(cos)) = nothing
+@test p.signature == :(f(t::typeof(Base.MPFR.cos)))
+@test p.modules == Set([:(Base.MPFR)])
+
 patches = [
     @patch f(h::Base.Dates.Hour=Base.Dates.Hour(rand())) = nothing
     @patch f(h::Dates.Hour=Dates.Hour(rand())) = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,11 @@ Mocking.enable()
 using Base.Test
 import Mocking: apply
 
+function next_gensym(str::AbstractString, offset::Integer=1)
+    m = match(r"^(.*?)(\d+)$", string(gensym(str)))
+    return Symbol(string(m.captures[1], parse(Int, m.captures[2]) + offset))
+end
+
 include("expr.jl")
 include("bindings/bindings.jl")
 include("patch.jl")
@@ -19,3 +24,4 @@ include("mock-in-patch.jl")
 include("readme.jl")
 include("optional.jl")
 include("patch-gen.jl")
+include("anonymous-param.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Base.Test
 import Mocking: apply
 
 include("expr.jl")
+include("bindings/bindings.jl")
 include("patch.jl")
 
 include("concept.jl")


### PR DESCRIPTION
Updated the binding extraction code to be much more accurate and work with the new Julia 0.6 syntax. These changes have allowed the absolute signature code to be drastically simplified. I've maintained support with Julia 0.4 for now but I'll probably drop Julia 0.4 and 0.5 support once this is merged and tagged.

Fixes #15