### PR TITLE
Finish renaming pre-compile

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -7,7 +7,11 @@ include("bindings.jl")
 include("options.jl")
 include("deprecated.jl")
 
-export @patch, @mock, Patch, apply, DISABLE_COMPILE_MODULES_STR, DISABLE_COMPILE_MODULES_CMD
+export
+    # Mocking.jl
+    @patch, @mock, Patch, apply,
+    # options.jl
+    DISABLE_COMPILED_MODULES_STR, DISABLE_COMPILED_MODULES_CMD
 
 # When ENABLED is false the @mock macro is a noop.
 global ENABLED = false
@@ -18,14 +22,14 @@ function enable(; force::Bool=false)
     global ENABLED = true
     global PATCH_ENV = PatchEnv()
 
-    if is_precompile_enabled()
+    if compiled_modules_enabled()
         if force
-            # Disable using pre-compiled packages when Mocking is enabled
-            use_precompile(false)
+            # Disable using compiled modules when Mocking is enabled
+            set_compiled_modules(false)
         else
             warn(
-                "Mocking.jl will probably not work when $COMPILE_MODULES_FLAG is enabled. ",
-                "Please start Julia with `$DISABLE_COMPILE_MODULES_STR` ",
+                "Mocking.jl will probably not work when $COMPILED_MODULES_FLAG is ",
+                "enabled. Please start `julia` with `$DISABLE_COMPILED_MODULES_STR` ",
                 "or alternatively call `Mocking.enable(force=true).`",
             )
         end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,11 +1,14 @@
-import Base: @deprecate_binding
+import Base: @deprecate_binding, @deprecate
 
 # BEGIN Mocking 0.4 deprecations
 
-@deprecate_binding PRECOMPILE_FLAG COMPILE_MODULES_FLAG false
-@deprecate_binding PRECOMPILE_FIELD COMPILE_MODULES_FIELD false
+@deprecate_binding PRECOMPILE_FLAG COMPILED_MODULES_FLAG false
+@deprecate_binding PRECOMPILE_FIELD COMPILED_MODULES_FIELD false
 
-@deprecate_binding DISABLE_PRECOMPILE_STR DISABLE_COMPILE_MODULES_STR
-@deprecate_binding DISABLE_PRECOMPILE_CMD DISABLE_COMPILE_MODULES_CMD
+@deprecate_binding DISABLE_PRECOMPILE_STR DISABLE_COMPILED_MODULES_STR
+@deprecate_binding DISABLE_PRECOMPILE_CMD DISABLE_COMPILED_MODULES_CMD
+
+@deprecate is_precompile_enabled compiled_modules_enabled false
+@deprecate use_precompile set_compiled_modules false
 
 # END Mocking 0.4 deprecations

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,19 +1,19 @@
 # Name of the `julia` command-line option
-const COMPILE_MODULES_FLAG = if VERSION >= v"0.7.0-DEV.1698"
+const COMPILED_MODULES_FLAG = if VERSION >= v"0.7.0-DEV.1698"
     Symbol("compiled-modules")
 else
     :compilecache
 end
 
 # Name of the field in the JLOptions structure which corresponds to the command-line option
-const COMPILE_MODULES_FIELD = if VERSION >= v"0.7.0-DEV.1698"
+const COMPILED_MODULES_FIELD = if VERSION >= v"0.7.0-DEV.1698"
     :use_compiled_modules
 else
     :use_compilecache
 end
 
-const DISABLE_COMPILE_MODULES_STR = "--$COMPILE_MODULES_FLAG=no"
-const DISABLE_COMPILE_MODULES_CMD = `$DISABLE_COMPILE_MODULES_STR`
+const DISABLE_COMPILED_MODULES_STR = "--$COMPILED_MODULES_FLAG=no"
+const DISABLE_COMPILED_MODULES_CMD = `$DISABLE_COMPILED_MODULES_STR`
 
 # Generate a mutable version of JLOptions
 let
@@ -27,23 +27,29 @@ let
     end
 end
 
-function is_precompile_enabled()
-    opts = Base.JLOptions()
-    field = COMPILE_MODULES_FIELD
+"""
+    compiled_modules_enabled() -> Bool
 
-    # When the pre-compile field is empty it means pre-compilation is unsupported. If the
-    # pre-compile field is missing that means pre-compilation to be assumed to be enabled.
+Determine if the `julia` command line flag `--$COMPILED_MODULES_FLAG` has been set to "yes".
+"""
+function compiled_modules_enabled()
+    opts = Base.JLOptions()
+    field = COMPILED_MODULES_FIELD
+
+    # When the field is set to `Symbol()` it means that compiled-modules is unsupported.
+    # If the compiled-modules field is undefined we assume that compiled-modules is enabled
+    # by default.
     return field != Symbol() && (!isdefined(opts, field) || Bool(getfield(opts, field)))
 end
 
 """
-    use_precompile(state::Bool) -> Void
+    set_compiled_modules(state::Bool) -> Void
 
-Override the Julia command line flag `--$COMPILE_MODULES_FLAG` with a runtime setting.
+Override the `julia` command line flag `--$COMPILED_MODULES_FLAG` with a runtime setting.
 Code run before this the value is modified will use the original setting. Not meant for
 general purpose usage.
 """
-function use_precompile(state::Bool)
+function set_compiled_modules(state::Bool)
     value = Base.convert(Int8, state)
 
     # Load the C global into a mutable Julia type
@@ -51,9 +57,9 @@ function use_precompile(state::Bool)
     opts = unsafe_load(jl_options)
 
     # Avoid modifying the global when the value hasn't changed
-    if getfield(opts, COMPILE_MODULES_FIELD) != value
+    if getfield(opts, COMPILED_MODULES_FIELD) != value
         warn("Using experimental code which modifies jl_options global struct")
-        setfield!(opts, COMPILE_MODULES_FIELD, value)
+        setfield!(opts, COMPILED_MODULES_FIELD, value)
         unsafe_store!(jl_options, opts)
     end
 

--- a/test/compiled-modules.jl
+++ b/test/compiled-modules.jl
@@ -1,0 +1,7 @@
+@testset "compiled_modules_enabled" begin
+    if VERSION >= v"0.7.0-DEV.1698"
+        @test Mocking.compiled_modules_enabled() == Bool(Base.JLOptions().use_compiled_modules)
+    else
+        @test Mocking.compiled_modules_enabled() == Bool(Base.JLOptions().use_compilecache)
+    end
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1,7 +1,0 @@
-@testset "is_precompile_enabled" begin
-    if VERSION >= v"0.7.0-DEV.1698"
-        @test Mocking.is_precompile_enabled() == Bool(Base.JLOptions().use_compiled_modules)
-    else
-        @test Mocking.is_precompile_enabled() == Bool(Base.JLOptions().use_compilecache)
-    end
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ function next_gensym(str::AbstractString, offset::Integer=1)
 end
 
 @testset "Mocking" begin
-    include("precompile.jl")
+    include("compiled-modules.jl")
     include("expr.jl")
     include("bindings/bindings.jl")
     include("patch.jl")


### PR DESCRIPTION
As part of #12 it was decided to move away from using "precompile" to talk about pre-compiled modules and instead use the Julia 0.7 term of "compiled modules". When updating the code I failed to update the functions using the precompile term and used "compile modules" instead of "compiled modules".