### PR TITLE
Fix latest Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 0.29

--- a/src/options.jl
+++ b/src/options.jl
@@ -21,7 +21,7 @@ let
     fields = [:($(fieldname(T,i))::$(fieldtype(T,i))) for i in 1:nfields(T)]
 
     @eval begin
-        type JLOptionsMutable
+        mutable struct JLOptionsMutable
             $(fields...)
         end
     end

--- a/src/options.jl
+++ b/src/options.jl
@@ -1,3 +1,5 @@
+import Compat: fieldcount
+
 # Name of the `julia` command-line option
 const COMPILED_MODULES_FLAG = if VERSION >= v"0.7.0-DEV.1698"
     Symbol("compiled-modules")
@@ -18,7 +20,7 @@ const DISABLE_COMPILED_MODULES_CMD = `$DISABLE_COMPILED_MODULES_STR`
 # Generate a mutable version of JLOptions
 let
     T = Base.JLOptions
-    fields = [:($(fieldname(T,i))::$(fieldtype(T,i))) for i in 1:nfields(T)]
+    fields = [:($(fieldname(T,i))::$(fieldtype(T,i))) for i in 1:fieldcount(T)]
 
     @eval begin
         mutable struct JLOptionsMutable


### PR DESCRIPTION
Fixing the deprecation for `nfields` works around this Base issue: https://github.com/JuliaLang/julia/issues/24658