### PR TITLE
Address some Julia 0.7 syntax changes

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -205,6 +205,7 @@ get_active_env() = PATCH_ENV::PatchEnv
 
 macro mock(expr)
     isa(expr, Expr) || error("argument is not an expression")
+    expr.head == :do && (expr = rewrite_do(expr))
     expr.head == :call || error("expression is not a function call")
     ENABLED::Bool || return esc(expr)  # @mock is a no-op when Mocking is not ENABLED
 

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -75,7 +75,11 @@ function convert(::Type{Expr}, p::Patch)
 
     # Generate imports for all required modules
     for (i, m) in enumerate(p.modules)
-        exprs[i] = Expr(:import, splitbinding(m)...)
+        if VERSION > v"0.7.0-DEV.3187"
+            exprs[i] = Expr(:import, Expr(:., splitbinding(m)...))
+        else
+            exprs[i] = Expr(:import, splitbinding(m)...)
+        end
     end
 
     # Generate the new method which will call the user's patch function. We need to perform

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -154,3 +154,10 @@ function call_parameters(expr::Expr)
     end
     return positional
 end
+
+# New do-block syntax introduced in: https://github.com/JuliaLang/julia/pull/23718
+function rewrite_do(expr::Expr)
+    expr.head == :do || error("expression is not a do-block")
+    call, body = expr.args
+    Expr(:call, call.args[1], body, call.args[2:end]...)
+end


### PR DESCRIPTION
- Changes to `import` syntax (https://github.com/JuliaLang/julia/pull/25256)
- Changes to `do` block syntax (https://github.com/JuliaLang/julia/pull/23718)