### PR TITLE
Explicitly import Compat features

### DIFF
--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -2,8 +2,7 @@ __precompile__(true)
 
 module Mocking
 
-using Compat
-using Compat: invokelatest, @info, @warn
+using Compat: @__MODULE__, hasmethod, invokelatest, undef, @info, @warn
 
 include("expr.jl")
 include("bindings.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Mocking
 Mocking.enable(force=true)
 
-using Compat
+using Compat: @__MODULE__
 using Compat.Test
 import Compat: Dates
 import Mocking: apply


### PR DESCRIPTION
By explicitly pulling only the features used from Compat it is easier to determine what version of Compat is actually required by the package and makes it easier to determine when the Compat package is not longer being used.