### PR TITLE
Handle nested modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Mocking
 
 Allows Julia function calls to be temporarily overloaded for purpose of testing.
 
+Contents
+--------
+
+- [Usage](#usage)
+- [Gotchas](#gotchas)
+- [Notes](#notes)
 
 Usage
 -----
@@ -77,6 +83,14 @@ end
 @test randdev(n) != convert(Array{UInt8}, n:-1:1)
 ```
 
+Gotchas
+-------
+
+Remember to:
+
+- use `@mock` at desired call sites
+- start julia with `--compiled-modules=no` (`--compilecache=no` for ≤0.6) or pass `force=true` to `Mocking.enable`
+- run `Mocking.enable` before importing the module(s) being tested
 
 Notes
 -----

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -53,7 +53,12 @@ struct Patch
         modules = Set()
         for b in values(trans)
             if isa(b, Expr)
-                push!(modules, b.args[1])
+                m = b.args[1]
+                while isa(m, Expr)
+                    push!(modules, m)
+                    m = m.args[1]
+                end
+                push!(modules, m)
             end
         end
 

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -79,6 +79,8 @@ function convert(::Type{Expr}, p::Patch)
     for m in p.modules
         bindings = splitbinding(m)
 
+        :Main in bindings && error("Mocking cannot handle bindings from Main.")
+
         for i in 1:length(bindings)
             import_expr = if VERSION > v"0.7.0-DEV.3187"
                 Expr(:import, Expr(:., bindings[1:i]...))

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -33,8 +33,8 @@ baz(f::ModB.AbstractFoo) = @mock bar(f)
 
 end
 
-import ModA
-import ModA: bar, baz, ModB
+import .ModA
+import .ModA: bar, baz, ModB
 
 @testset "patch" begin
     @testset "basic" begin

--- a/test/patch.jl
+++ b/test/patch.jl
@@ -116,7 +116,7 @@ import .ModA: bar, baz, ModB
         As a result, we're opting to throw an error in that condition.
         NOTE: Dropping 0.6 should allow us to use Cassette.jl and avoid this issue.
         =#
-        p = @patch bar(f::ModB.AbstractFoo) = nothing
+        p = @patch bar(f::ModB.AbstractFoo) = "mock"
         if VERSION >= v"0.7.0-DEV.1877"
             @test_throws ErrorException Mocking.convert(Expr, p)
         else
@@ -126,10 +126,9 @@ import .ModA: bar, baz, ModB
                 bar(f::ModA.ModB.AbstractFoo) = $(p.body)(f)
             end
             @test Mocking.convert(Expr, p) == strip_lineno!(expected)
-            resp = Mocking.apply(p) do
-                baz(ModB.Foo("X"))
+            Mocking.apply(p) do
+                @test baz(ModB.Foo("X")) == "mock"
             end
-            @test resp === nothing
         end
     end
 


### PR DESCRIPTION
Currently, using nested modules can result in an `UndefVarError`.

```
julia> using Mocking

julia> Mocking.enable(; force=true)
Warning: Using experimental code which modifies jl_options global struct

julia> module A

       module B

       abstract type AbstractFoo end

       struct Foo <: AbstractFoo
           x::String
       end

       end

       bar(f::B.AbstractFoo) = println("blah")

       end
A

julia> import A: bar

julia> patch = @patch bar(f::B.AbstractFoo) = println("blar")
Mocking.Patch(:(bar(f::A.B.AbstractFoo)), ##665, Set(Any[:(A.B)]))

julia> Mocking.apply(patch) do
           bar(B.Foo("Blar"))
       end
ERROR: UndefVarError: A not defined
Stacktrace:
 [1] Mocking.PatchEnv(::Mocking.Patch, ::Bool) at /Users/rory/.playground/share/mocking/packages/v0.6/Mocking/src/Mocking.jl:156
 [2] apply(::Function, ::Mocking.Patch) at /Users/rory/.playground/share/mocking/packages/v0.6/Mocking/src/Mocking.jl:184
```

This is because the patch is only importing the top level module while the method is using a fully specified type signature:

```
ulia> Mocking.convert(Expr, patch)
quote
    import A.B
    bar(f::A.B.AbstractFoo) = begin
            (##662)(f)
        end
end
```

The solution should be to just recursively import all the parent modules.