### PR TITLE
Fix debugging messages

### DIFF
--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -54,9 +54,7 @@ and the generic function of the method.
 When the function to dispatch to is ambiguous last ambiguous function in the vector is used.
 """
 function dispatch(funcs::AbstractVector, args...)
-    arg_types = map(args) do arg
-        arg isa DataType ? Type{arg} : typeof(arg)
-    end
+    arg_types = map(Core.Typeof, args)
 
     best_method = nothing
     best_function = nothing

--- a/src/mock.jl
+++ b/src/mock.jl
@@ -38,18 +38,27 @@ function get_alternate(pe::PatchEnv, target, args...)
         m, f = dispatch(pe.mapping[target], args...)
 
         if pe.debug
-            @info "calling mocked method: $m"
+            if m !== nothing
+                @info _debug_msg(m, target, args)
+            else
+                target_m, _ = dispatch([target], args...)
+                @info _debug_msg(target_m, target, args)
+            end
         end
 
         return f
     else
-        if pe.debug
-            m, f = dispatch([target], args...)  # just looking up `m` for logging purposes
-            @info "calling original method: $m"
-        end
-
         return nothing
     end
 end
 
 get_alternate(target, args...) = get_alternate(get_active_env(), target, args...)
+
+function _debug_msg(method::Method, target, args)
+    call = "$target($(join(map(arg -> "::$(Core.Typeof(arg))", args), ", ")))"
+    return """
+        Mocking intercepted:
+        call:       $call
+        dispatched: $method
+        """
+end

--- a/test/import.jl
+++ b/test/import.jl
@@ -2,7 +2,7 @@
 @testset "imported binding in body" begin
     @test_throws UndefVarError Minute
     @test isdefined(Dates, :Minute)
-    import Dates: Minute, Hour
+    using Dates: Minute, Hour
 
     myminute(x::Integer) = Minute(x)
 
@@ -27,7 +27,7 @@ end
 
 # Patches should allow using imported bindings syntax in the signature
 @testset "imported binding in signature" begin
-    import Base: AbstractCmd
+    using Base: AbstractCmd
 
     patch = @patch read(cmd::AbstractCmd, ::Type{String}) = "bar"
     apply(patch) do


### PR DESCRIPTION
I messed the logic up when implementing `get_alternate`. The original method output should be provided when a patch is present for the target function but we do not use the alternate version due to the alternate signature not matching the arguments provided.