### PR TITLE
Support required keywords in `@mock`

### DIFF
--- a/src/expr.jl
+++ b/src/expr.jl
@@ -8,13 +8,13 @@ end
 iskwarg(x::Any) = isa(x, Expr) && (x.head === :parameters || x.head === :kw)
 
 """
-    extract_kwargs(expr::Expr) -> Vector{Expr}
+    extract_kwargs(expr::Expr) -> Vector{Union{Expr,Symbol}}
 
 Extract the :parameters and :kw value into an array of :kw expressions
 we don't evaluate any expressions for values yet though.
 """
 function extract_kwargs(expr::Expr)
-    kwargs = Expr[]
+    kwargs = Union{Expr,Symbol}[]
     for x in expr.args[2:end]
         if iskwarg(x)
             if x.head === :parameters

--- a/test/mock.jl
+++ b/test/mock.jl
@@ -6,17 +6,21 @@
         return @mock f(; x=x)
     end
 
+    @test f_param() == 2
+
     function f_kw()
         x = 3
         return @mock f(x=x)
     end
 
-    function f_req_param()
-        x = 4
-        return @mock f(; x)  # Testing keyword parameter that is just a `Symbol`
-    end
-
-    @test f_param() == 2
     @test f_kw() == 3
-    @test f_req_param() == 4
+
+    @static if VERSION >= v"1.5"
+        function f_req_param()
+            x = 4
+            return @mock f(; x)  # Testing keyword parameter that is just a `Symbol`
+        end
+
+        @test f_req_param() == 4
+    end
 end

--- a/test/mock.jl
+++ b/test/mock.jl
@@ -1,0 +1,22 @@
+@testset "mock keyword" begin
+    f(; x=1) = x
+
+    function f_param()
+        x = 2
+        return @mock f(; x=x)
+    end
+
+    function f_kw()
+        x = 3
+        return @mock f(x=x)
+    end
+
+    function f_req_param()
+        x = 4
+        return @mock f(; x)  # Testing keyword parameter that is just a `Symbol`
+    end
+
+    @test f_param() == 2
+    @test f_kw() == 3
+    @test f_req_param() == 4
+end

--- a/test/optional.jl
+++ b/test/optional.jl
@@ -9,7 +9,7 @@
     end
 end
 
-# Creating a patch with an keyword parameter
+# Creating a patch with a keyword parameter
 @testset "patch with keyword parameter" begin
     hourvalue(; hour::Hour=Hour(0)) = Dates.value(hour)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Mocking: anon_morespecific, anonymous_signature, dispatch, type_morespecif
 
 @testset "Mocking" begin
     include("dispatch.jl")
+    include("mock.jl")
     include("patch.jl")
 
     include("concept.jl")


### PR DESCRIPTION
Fixes https://github.com/invenia/Mocking.jl/issues/85