### PR TITLE
Add ColPrac badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Mocking
 [![CI](https://github.com/Invenia/Mocking.jl/workflows/CI/badge.svg)](https://github.com/Invenia/Mocking.jl/actions?query=workflow%3ACI)
 [![codecov.io](http://codecov.io/github/invenia/Mocking.jl/coverage.svg?branch=master)](http://codecov.io/github/invenia/Mocking.jl?branch=master)
 
-[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle) [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle) 
+[![ColPrac: Contributor Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
 
 Allows Julia function calls to be temporarily overloaded for purpose of testing.


### PR DESCRIPTION
This repo should have the ColPrac badge.
ColPrac is basically a open source extension of Invenia's internal rules.
Having it linked here means it is also known to external contibutors.