### PR TITLE
RFC: add debug logging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ version = "0.7.3"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 Compat = "3.9"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Remember to:
     - Also note `Mocking.activate()` needs to be called at top-level because it uses `@eval`
       under the hood, so can run into world age issues if called within a function
 
+For debugging (e.g. if patches are not being applied as expected), use
+stdlib [`Logging`](https://docs.julialang.org/en/v1/stdlib/Logging) with level set to `Debug`,
+for example:
+```
+using Logging
+global_logger(ConsoleLogger(stderr, Logging.Debug))
+
+Mocking.activate()
+...
+```
+Calls to Mocking functions will then print some debugging info when called.
+
 Overhead
 --------
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Remember to:
 
 - Use `@mock` at desired call sites
 - Run `Mocking.activate()` before executing any `apply` calls
+    - Also note `Mocking.activate()` needs to be called at top-level because it uses `@eval`
+      under the hood, so can run into world age issues if called within a function
 
 Overhead
 --------

--- a/src/Mocking.jl
+++ b/src/Mocking.jl
@@ -20,6 +20,7 @@ activated() = false
 Enable `@mock` call sites to allow for calling patches instead of the original function.
 """
 function activate()
+    @debug "Calling Mocking.activate()"
     # Avoid redefining `activated` when it's already set appropriately
     !activated() && @eval activated() = true
     return nothing
@@ -31,6 +32,7 @@ end
 Disable `@mock` call sites to only call the original function.
 """
 function deactivate()
+    @debug "Calling Mocking.deactivate()"
     # Avoid redefining `activated` when it's already set appropriately
     activated() && @eval activated() = false
     return nothing
@@ -50,6 +52,7 @@ Note to ensure that all `@mock` macros are inoperative be sure to call this func
 loading any packages which depend on Mocking.jl.
 """
 function nullify()
+    @debug "Calling Mocking.nullify()"
     global NULLIFIED[] = true
     return nothing
 end

--- a/src/patch.jl
+++ b/src/patch.jl
@@ -76,6 +76,7 @@ function Base.merge(pe1::PatchEnv, pe2::PatchEnv)
 end
 
 function apply!(pe::PatchEnv, p::Patch)
+    @debug "Applying patch" p
     alternate_funcs = get!(Vector{Function}, pe.mapping, p.target)
     push!(alternate_funcs, p.alternate)
     return pe

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -1,0 +1,54 @@
+using Logging
+
+@testset "logging" begin
+    activated_before_tests = Mocking.activated()
+
+    buf = IOBuffer()
+    logger = ConsoleLogger(IOContext(buf), Logging.Debug)
+
+    # Note: ending the `with_logger` do block right after `activate()` because `activate()`
+    # uses @eval under the hood, and so Mocking will only be `activated()` once out of the
+    # function scope (created by the do block syntax).
+    # Same for `deactivate()` further down.
+    with_logger(logger) do
+        Mocking.activate()
+        @test occursin("Calling Mocking.activate()", String(take!(buf)))
+    end
+
+    f() = 1
+    f(x) = 1
+
+    p1 = @patch f() = 2
+    
+    with_logger(logger) do
+        Mocking.apply(p1) do
+            @test occursin("Applying patch", String(take!(buf)))
+
+            @mock f()
+            log = String(take!(buf))
+            @test occursin("Mocking activated, @mock macro expanding to `get_alternate` for target", log)
+            @test occursin("Triggering patch", log)
+
+            @mock f(1)
+            @test occursin("Not triggering any patch", String(take!(buf)))
+        end
+    end
+
+    with_logger(logger) do
+        Mocking.deactivate()
+        @test occursin("Calling Mocking.deactivate()", String(take!(buf)))
+    end
+
+    with_logger(logger) do
+        Mocking.apply(p1) do
+            @test occursin("Applying patch", String(take!(buf)))
+
+            @mock f()
+            @test occursin("Mocking not activated, @mock macro expanding to the original target", String(take!(buf)))
+        end
+    end
+
+    if activated_before_tests
+        Mocking.activate()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,4 +30,6 @@ using Mocking: anon_morespecific, anonymous_signature, dispatch, type_morespecif
     include("nested_apply.jl")
     include("async.jl")
     include("issues.jl")
+
+    include("logging.jl")
 end


### PR DESCRIPTION
We (at [invenia](https://github.com/invenia)) are bumping into an issue in our CI tests, where some mock patches are not being applied despite calling `Mocking.activate` and `Mocking.apply(patches)` correctly. This happens sporadically (most of the times the patches do get applied) and we are quite stumbled by it.

Having debug statements in Mocking.jl as proposed in this PR would hopefully give us a hint towards what the issue could be, i.e. are the patches not applied because:
1. Mocking is not `activated`
2. Mocking has been `deactivated` or `nullified` somewhere
3. The patch doesn't match the patch entries in the `PatchEnv` being used

Some potential concerns with this PR:
1. Could this add overhead and cause unacceptable slow-downs in existing code?
2. I saw there is already a `debug::Bool` flag used to print `@info` messages inside `get_alternate`, however I couldn't re-use this since it is tied to the `PatchEnv`, and some statements I'm adding are in scopes outside a patch env (e.g. when calling `Mocking.activate`). This means there is overlapping logic/intent with that, but not sure how best to deal with this in the long term (perhaps deprecate `debug::Bool` in favour of Logging levels?)