### PR TITLE
Support Compat@4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,14 @@ keywords = ["testing", "mocking"]
 license = "MIT"
 desc = "Allows Julia function calls to be temporarily overloaded for purpose of testing"
 author = ["Curtis Vogt"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 
 [compat]
-Compat = "3.9"
+Compat = "3.9, 4"
 ExprTools = "0.1"
 julia = "1"
 


### PR DESCRIPTION
This PR adds support for Compat >= 4. In 4.0.0 many dependencies were removed by dropping support for Julia < 1.6.

It seems CompatHelper does not create PRs for Compat@4 currently (same happened in e.g. CRC). I wonder if the problem is that CompatHelper pulls in Compat@3, possibly due to its dependency on Mocking. So possibly updating Mocking will resolve the issue.