### PR TITLE
Change version number to 0.7.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["testing", "mocking"]
 license = "MIT"
 desc = "Allows Julia function calls to be temporarily overloaded for purpose of testing"
 author = ["Curtis Vogt"]
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
The current version in the Julia registry is still 0.7.3 since 0.7.4 was yanked due to [problems with ContextVariablesX.jl](https://github.com/invenia/Mocking.jl/pull/93). Some commits later [a new version was tried to be registered](https://github.com/invenia/Mocking.jl/commit/1eb1e7fb3783c0a78900d6880bcac368905a464f) which did fail due to reuse of the yanked version number. This PR increments the version number such that a new version can be registered.