### PR TITLE
Use `julia-version` for matrix job creation

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
       json: ${{ steps.julia-version.outputs.resolved-json }}
     steps:
       - uses: actions/checkout@v6 # Needed for "min" to access the Project.toml
-      - uses: julia-actions/julia-version@v1
+      - uses: julia-actions/julia-version@v0.1.0
         id: julia-version
         with:
           versions: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,16 +13,33 @@ on:
       - ".codecov.yaml"
       - ".github/workflows/CI.yaml"
 jobs:
+  version:
+    name: Resolve Julia Versions
+    # These permissions are needed to:
+    # - Checkout the Git repository (`contents: read`)
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.julia-version.outputs.resolved-json }}
+    steps:
+      - uses: actions/checkout@v6 # Needed for "min" to access the Project.toml
+      - uses: julia-actions/julia-version@v1
+        id: julia-version
+        with:
+          versions: |
+            - min  # Project's oldest supported version
+            - lts  # Long-Term Stable
+            - 1    # Latest release
+
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    needs: version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - "min"  # Oldest supported version
-          - "lts"  # LTS
-          - "1"    # Latest Release
+        version: ${{ fromJSON(needs.version.outputs.json) }}
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Using this has two advantages:
- We can reduce the number of CI jobs when version specifiers resolve to the same version
- The Julia version used can be shown in the job name